### PR TITLE
Running an exec command now returns the response to that command.

### DIFF
--- a/Telnet.class.php
+++ b/Telnet.class.php
@@ -48,11 +48,12 @@ class Telnet {
 	 * @param int $timeout Connection timeout in seconds
 	 * @return void
 	 */
-	public function __construct($host = '127.0.0.1', $port = '23', $timeout = 10){
+	public function __construct($host = '127.0.0.1', $port = '23', $timeout = 10, $prompt='$'){
 
 		$this->host = $host;
 		$this->port = $port;
 		$this->timeout = $timeout;
+		$this->prompt = $prompt;
 
 		// set some telnet special characters
 		$this->NULL = chr(0);
@@ -107,6 +108,8 @@ class Telnet {
 		if (!$this->socket){
 			throw new Exception("Cannot connect to $this->host on port $this->port");
 		}
+		
+		$this->waitPrompt();
 
 		return self::TELNET_OK;
 	}


### PR DESCRIPTION
My server on connection would show the text "Waiting for Command". In telnet I would then type "auth user pass". Then the server would return "Authorized".

Using this class I would connect to my server, and use the following code:

```
$response = $telnet->exec('auth user pass');
```

And `$response` would be equal to "Waiting for Command". This is because the server I am telneting into uses \n before prompting instead of $.

So I added an initial `waitPrompt()` call to ensure that once I started to execute commands I would get the response to that command and not to the previous one.
